### PR TITLE
fix: workspace config connection as map instead of slice

### DIFF
--- a/modelv2/workspaceconfigs.go
+++ b/modelv2/workspaceconfigs.go
@@ -16,7 +16,7 @@ type WorkspaceConfig struct {
 	Settings                         *Settings                          `json:"settings"`
 	Sources                          map[string]*Source                 `json:"sources"`
 	Destinations                     map[string]*Destination            `json:"destinations"`
-	Connections                      []*Connection                      `json:"connections"`
+	Connections                      map[string]*Connection             `json:"connections"`
 	Libraries                        []*Library                         `json:"libraries"`
 	WHTProjects                      map[string]*WHTProject             `json:"whtProjects"`
 	Accounts                         map[string]*Account                `json:"accounts"`


### PR DESCRIPTION
# Description

- Connections are coming as maps instead of slices.

## Linear Ticket

< Replace_with_Linear_Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
