### PR TITLE
chore: raw workspace configs

### DIFF
--- a/internal/clients/base/client.go
+++ b/internal/clients/base/client.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/rudderlabs/rudder-go-kit/httputil"
 )
 
 type Client struct {
@@ -36,7 +38,9 @@ func (c *Client) Send(req *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		httputil.CloseResponse(res)
+	}()
 
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)

--- a/internal/clients/namespace/client.go
+++ b/internal/clients/namespace/client.go
@@ -28,13 +28,22 @@ func (c *Client) Get(ctx context.Context, path string) (*http.Request, error) {
 	return req, nil
 }
 
-func (c *Client) GetWorkspaceConfigs(ctx context.Context) (*modelv2.WorkspaceConfigs, error) {
+func (c *Client) GetRawWorkspaceConfigs(ctx context.Context) ([]byte, error) {
 	req, err := c.Get(ctx, "/data-plane/v2/namespaces/"+c.Identity.Namespace+"/config")
 	if err != nil {
 		return nil, err
 	}
 
 	data, err := c.Send(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (c *Client) GetWorkspaceConfigs(ctx context.Context) (*modelv2.WorkspaceConfigs, error) {
+	data, err := c.GetRawWorkspaceConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/clients/workspace/client.go
+++ b/internal/clients/workspace/client.go
@@ -28,13 +28,22 @@ func (c *Client) Get(ctx context.Context, path string) (*http.Request, error) {
 	return req, nil
 }
 
-func (c *Client) GetWorkspaceConfigs(ctx context.Context) (*modelv2.WorkspaceConfigs, error) {
+func (c *Client) GetRawWorkspaceConfigs(ctx context.Context) ([]byte, error) {
 	req, err := c.Get(ctx, "/data-plane/v2/workspaceConfig")
 	if err != nil {
 		return nil, err
 	}
 
 	data, err := c.Send(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (c *Client) GetWorkspaceConfigs(ctx context.Context) (*modelv2.WorkspaceConfigs, error) {
+	data, err := c.GetRawWorkspaceConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk.go
+++ b/sdk.go
@@ -43,6 +43,7 @@ type ControlPlane struct {
 
 type Client interface {
 	GetWorkspaceConfigs(ctx context.Context) (*modelv2.WorkspaceConfigs, error)
+	GetRawWorkspaceConfigs(ctx context.Context) ([]byte, error)
 	GetUpdatedWorkspaceConfigs(ctx context.Context, updatedAfter time.Time) (*modelv2.WorkspaceConfigs, error)
 }
 
@@ -152,6 +153,12 @@ func (cp *ControlPlane) GetWorkspaceConfigs() (*modelv2.WorkspaceConfigs, error)
 	} else {
 		return cp.Client.GetWorkspaceConfigs(context.Background())
 	}
+}
+
+// GetRawWorkspaceConfigs returns the raw workspace configs.
+// Currently, it does not support for incremental updates.
+func (cp *ControlPlane) GetRawWorkspaceConfigs() ([]byte, error) {
+	return cp.Client.GetRawWorkspaceConfigs(context.Background())
 }
 
 type Subscriber interface {

--- a/sdk.go
+++ b/sdk.go
@@ -155,8 +155,7 @@ func (cp *ControlPlane) GetWorkspaceConfigs() (*modelv2.WorkspaceConfigs, error)
 	}
 }
 
-// GetRawWorkspaceConfigs returns the raw workspace configs.
-// Currently, it does not support for incremental updates.
+// GetRawWorkspaceConfigs returns the raw workspace configs. It does not support for incremental updates.
 func (cp *ControlPlane) GetRawWorkspaceConfigs() ([]byte, error) {
 	return cp.Client.GetRawWorkspaceConfigs(context.Background())
 }


### PR DESCRIPTION
# Description

- Current Implementation: if the poller is set, it makes an API call to get the workspace config, stores it in the cache, and informs the client through the notification. The client then gets the configs from the cache.
- The initial idea was to implement `WithoutCache` and `WithoutParsing`.
- WithoutCache: 
  - If the poller is set, then it makes an API call to get the workspace config, discards the response **because of the no-cache policy,** and **informs the client through the notification**. The client then makes the **API call to fetch the response since it's not present in the cache**. **Since the response fetched by the poller is not being used, no need to have the poller.** **It can also send the data through the Notification, but in that case, it would not work for incremental updates because the client needs to store the relevant stuff.**
  - **If the poller is not set. then there is nothing in the cache and the client will need to fetch the response.**
  - **In general, it would not work for incremental updates because the client needs to store the relevant stuff and merge the configs**
- WithoutParsing: 
  - **It was getting complicated to support both the raw JSON and modelv2.WorkspaceConfigs within the cache. So introduced a new API at an SDK level `GetRawWorkspaceConfigs` to make the API call and get the config.**
  - **In general, it would not work for incremental updates because the client needs to store the relevant stuff and merge the configs**

## Linear Ticket

- Resolves PIPE-751

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
