### PR TITLE
fix: options does not update baseURL v2

### DIFF
--- a/options.go
+++ b/options.go
@@ -5,8 +5,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/rudderlabs/rudder-cp-sdk/identity"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+
+	"github.com/rudderlabs/rudder-cp-sdk/identity"
 )
 
 type Option func(*ControlPlane) error
@@ -43,6 +44,7 @@ func WithBaseUrl(baseUrl string) Option {
 		}
 
 		cp.baseUrl = url
+		cp.baseUrlV2 = url
 		return nil
 	}
 }


### PR DESCRIPTION
# Description

- In the previous https://github.com/rudderlabs/rudder-cp-sdk/pull/44/files, default URL v2 got added for the namespace endpoint. Although I tested the changes with ingestion svc and it worked because we use `WithBaseUrl` to set the config backend URL, and since it didn't update the v2 URL, it pointed to the default "https://dp.api.rudderstack.com" and it worked.
- Some tests were failing, and it was supposed to be because the path got changed and I thought I would fix it later. But even when I fixed it, it didn't work because Options did not set baseURL v2.
- Although I agree we should have a test in this repo itself and we also planned as well to add a Kind-based test but not at a priority.

## Linear Ticket

- Resolves PIPE-1185

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
