### PR TITLE
chore: context propagation for tracing

### DIFF
--- a/cmd/sampleapp/main.go
+++ b/cmd/sampleapp/main.go
@@ -81,7 +81,7 @@ func setupWorkspaceConfigsPoller[K comparable](
 		poller.WithPollingMaxElapsedTime[K](5*time.Minute),
 		poller.WithPollingMaxRetries[K](15),
 		poller.WithPollingBackoffMultiplier[K](1.5),
-		poller.WithOnResponse[K](func(updated bool, err error) {
+		poller.WithOnResponse[K](func(_ context.Context, updated bool, err error) {
 			if err != nil {
 				// e.g. bump metric on failure
 				log.Errorn("failed to poll workspace configs", obskit.Error(err))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-cp-sdk
 
-go 1.23.4
+go 1.24.1
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-cp-sdk
 
-go 1.24.1
+go 1.23.4
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/poller/options.go
+++ b/poller/options.go
@@ -1,6 +1,7 @@
 package poller
 
 import (
+	"context"
 	"time"
 
 	"github.com/rudderlabs/rudder-go-kit/logger"
@@ -36,6 +37,6 @@ func WithPollingBackoffMultiplier[K comparable](m float64) Option[K] {
 	return func(p *WorkspaceConfigsPoller[K]) { p.backoff.multiplier = m }
 }
 
-func WithOnResponse[K comparable](f func(bool, error)) Option[K] {
+func WithOnResponse[K comparable](f func(context.Context, bool, error)) Option[K] {
 	return func(p *WorkspaceConfigsPoller[K]) { p.onResponse = f }
 }


### PR DESCRIPTION
# Description

Propagating context in `onResponse` callback for tracing in poller.

See [this PR](https://github.com/rudderlabs/rudder-ingestion-svc/pull/349) for more context.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
