### PR TITLE
fix: correct struct field ordering in ControlPlane definition

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -21,6 +21,9 @@ const (
 )
 
 type ControlPlane struct {
+	Client      Client
+	AdminClient *admin.Client
+
 	baseUrl           *url.URL
 	baseUrlV2         *url.URL
 	workspaceIdentity *identity.Workspace
@@ -28,11 +31,7 @@ type ControlPlane struct {
 	adminCredentials  *identity.AdminCredentials
 
 	httpClient RequestDoer
-
-	Client      Client
-	AdminClient *admin.Client
-
-	log logger.Logger
+	log        logger.Logger
 }
 
 type Client interface {


### PR DESCRIPTION
# Description

Just some changes to trigger a build to avoid getting the following:

> No user facing commits found since 65990878c3ee926be65cf9681874f9b64f6d1d94 - skipping

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
